### PR TITLE
lavfmuxer: support codecpar and prevent core dumps because of uninitialized parameters

### DIFF
--- a/src/lavfmuxer.cpp
+++ b/src/lavfmuxer.cpp
@@ -61,9 +61,10 @@ lavfmuxer::lavfmuxer(const char *format, uint32_t audiostreammask, mpgfile &mpg,
   s->sample_aspect_ratio = codec->sample_aspect_ratio;
   s->time_base = codec->time_base;
 
+  int ret = 0;
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 14, 0)
   // Use Parameters instead of Codec, necessary to get correct results, prevent crash and correct display of the output of av_dump
-  int ret = avcodec_parameters_from_context(s->codecpar, codec);
+  ret = avcodec_parameters_from_context(s->codecpar, codec);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR, "Failed to copy encoder parameters to output stream #%u\n", s->id);
     return;
@@ -117,7 +118,7 @@ lavfmuxer::lavfmuxer(const char *format, uint32_t audiostreammask, mpgfile &mpg,
         av_log(NULL, AV_LOG_ERROR, "Failed to copy encoder parameters to output stream #%u\n", s->id);
         return;
       }
-#endif      
+#endif
     }
 
   if (!(fmt->flags & AVFMT_NOFILE)&&(avio_open(&avfc->pb, filename, AVIO_FLAG_WRITE) < 0)) {


### PR DESCRIPTION
Fix for dvbcut to support the new introduced codecpar as replacement of codec. Newer versions of ffmpeg now rely on them. If not provided export produces coredumps.